### PR TITLE
Fix put profile not userId.

### DIFF
--- a/src/main/java/cn.canlnac.course/controller/user/ProfileController.java
+++ b/src/main/java/cn.canlnac.course/controller/user/ProfileController.java
@@ -196,6 +196,7 @@ public class ProfileController {
         if(profile.getId() > 0){
             count = profileService.update(profile);
         } else {
+            profile.setUserId(Integer.parseInt(auth.get("id").toString()));
             count = profileService.create(profile);
         }
 


### PR DESCRIPTION
修复用户创建资料时，没有设置用户ID，导致一直没有个人资料。